### PR TITLE
shifting queue in emulation mode

### DIFF
--- a/chrome_extension/background/event.js
+++ b/chrome_extension/background/event.js
@@ -427,6 +427,12 @@ mooltipassEvent.onUpdateNotify = function(callback, tab, username, password, url
 			}
 			else if(mooltipass.device.emulation_mode)
 			{
+				var notification = {   
+					type: 'basic',
+					title: 'Subdomain Detected!',
+					message: 'What domain do you want to store?',
+					iconUrl: '/icons/question.png',
+				};
 				notification.message = 'Please approve Domain storage';
 				mooltipass.device.updateCredentials(null, tab, 0, username, password, domain);
 				cross_notification(noteId,notification);				

--- a/chrome_extension/vendor/mooltipass/device.js
+++ b/chrome_extension/vendor/mooltipass/device.js
@@ -295,37 +295,43 @@ mooltipass.device.sendCredentialRequestMessageFromQueue = function()
         // Send the message
         if (mooltipass.device.emulation_mode)
         {
-            for (var i = 0; i < mooltipass.device.emulation_credentials.length; i++)
+            // Put everything in a timeout to avoid duplicate requests
+            setTimeout(function()
             {
-                if (mooltipass.device.emulation_credentials[i]["domain"] == mooltipass.device.retrieveCredentialsQueue[0].domain)
+                for (var i = 0; i < mooltipass.device.emulation_credentials.length; i++)
                 {
-                    if (background_debug_msg > 3) mpDebug.log("%c Emulation mode: found credential in buffer:", mpDebug.css('00ff00'), mooltipass.device.emulation_credentials[i]);
-                    setTimeout(function() 
+                    if (mooltipass.device.emulation_credentials[i]["domain"] == mooltipass.device.retrieveCredentialsQueue[0].domain)
                     {
-                        try
+                        if (background_debug_msg > 3) mpDebug.log("%c Emulation mode: found credential in buffer:", mpDebug.css('00ff00'), mooltipass.device.emulation_credentials[i]);
+                        setTimeout(function() 
                         {
-                            mooltipass.device.retrieveCredentialsQueue[0].callback([
-                                {
-                                    Login: mooltipass.device.emulation_credentials[i]["login"],
-                                    Name: '<name>',
-                                    Uuid: '<Uuid>',
-                                    Password: mooltipass.device.emulation_credentials[i]["password"],
-                                    StringFields: []
-                                }
-                            ], mooltipass.device.retrieveCredentialsQueue[0].tabid == 'safari'?mooltipass.device.retrieveCredentialsQueue[0].tab:mooltipass.device.retrieveCredentialsQueue[0].tabid );
-                        }
-                        catch(err)
-                        {
-                            //console.log( err );
-                        }
-                        // Treat other pending requests
-                        mooltipass.device.retrieveCredentialsQueue.shift();
-                        mooltipass.device.sendCredentialRequestMessageFromQueue();
-                    }, 2000);
-                    return;
+                            try
+                            {
+                                mooltipass.device.retrieveCredentialsQueue[0].callback([
+                                    {
+                                        Login: mooltipass.device.emulation_credentials[i]["login"],
+                                        Name: '<name>',
+                                        Uuid: '<Uuid>',
+                                        Password: mooltipass.device.emulation_credentials[i]["password"],
+                                        StringFields: []
+                                    }
+                                ], mooltipass.device.retrieveCredentialsQueue[0].tabid == 'safari'?mooltipass.device.retrieveCredentialsQueue[0].tab:mooltipass.device.retrieveCredentialsQueue[0].tabid );
+                            }
+                            catch(err)
+                            {
+                                //console.log( err );
+                            }
+                            // Treat other pending requests
+                            mooltipass.device.retrieveCredentialsQueue.shift();
+                            mooltipass.device.sendCredentialRequestMessageFromQueue();
+                        }, 2000);
+                        return;
+                    }
                 }
-            }
-            if (background_debug_msg > 3) mpDebug.log("%c Emulation mode: nothing in buffer!", mpDebug.css('00ff00'));
+                if (background_debug_msg > 3) mpDebug.log("%c Emulation mode: nothing in buffer!", mpDebug.css('00ff00'));
+                mooltipass.device.retrieveCredentialsQueue.shift();
+                mooltipass.device.sendCredentialRequestMessageFromQueue();
+            }, 300);
         }
         else if (mooltipass.device.connectedToExternalApp) 
         {


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   