### PR TITLE
script updated for emualtion mode

### DIFF
--- a/chrome_extension/updateCleanVersion.sh
+++ b/chrome_extension/updateCleanVersion.sh
@@ -9,6 +9,8 @@ EXTENSION_NAME='mooltipass-extension'
 BUILD_FIREFOX=0
 BUILD_CHROMIUM=0
 
+ENABLE_EMULTATION_MODE=0
+
 # Array to store different information used during building different extension package.
 # Typically it is expected to found path to key used to sign extension before sending
 # them to the store.
@@ -68,6 +70,10 @@ function main()
                  ;;
              '--test')
                  test_only=1
+                 shift
+                 ;;
+             '--emulation-mode')
+                 ENABLE_EMULTATION_MODE=1
                  shift
                  ;;
              *)
@@ -241,6 +247,13 @@ function _inject_scripts()
     for ext_dir in vendor popups css options background images icons; do
         cp -Rf "${CWD}/${ext_dir}" "${OUTPUT_DIR}/"
     done
+
+    if [ "${ENABLE_EMULTATION_MODE}" != '0' ] && [ -f "${CWD}/vendor/mooltipass/device.js" ]; then
+        if ! sed -i 's/mooltipass.device.emulation_mode = false/mooltipass.device.emulation_mode = true/' \
+             "${OUTPUT_DIR}/vendor/mooltipass/device.js"; then
+            echo "[ERROR] Cannot set emulation mode" 1>&2
+        fi
+    fi
 }
 
 # performs a list of tests on the extension archive directory

--- a/chrome_extension/updateCleanVersion.sh
+++ b/chrome_extension/updateCleanVersion.sh
@@ -293,7 +293,7 @@ EOF
     fi
 
     cat <<EOF 1>&2
-Usage: $prog_name [--extension-name NAME] [TARGET] [--test]
+Usage: $prog_name [OPTION]... [--extension-name NAME] [TARGET] [--test]
 where TARGET := --target {chrome | chromium | firefox} --sign-key SIGN_KEY
 
       --extension-name  name of the generated extension files
@@ -301,6 +301,11 @@ where TARGET := --target {chrome | chromium | firefox} --sign-key SIGN_KEY
       --sign-key        path to signature key file for the specific target (ie: Chromium, Firefox...)
       --target          create a clean directory for the given target chromium(default)
       --test            only perform test, no packages are created
+
+options:
+        --emulation-mode        This will set the emulate mode in the base archive
+                                (see mooltipass.device.emulation_mode under device.js)
+
 EOF
 
     exit 1


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   